### PR TITLE
Merge sfrinaldi/edit-report-names into develop

### DIFF
--- a/src/budgie/core/mission_lifetime.py
+++ b/src/budgie/core/mission_lifetime.py
@@ -173,7 +173,7 @@ class MissionLifetime(Budget):
         # Method that is called by a generic script
         # needs to be in every budget class.
         print("Running report method for mission lifetime...")
-        report_name = NAME.replace(".yaml", "md")
+        report_name = NAME.replace(".yaml", ".md")
         path = output_dir.joinpath(report_name)
         yaml = pprint.pformat(self.ml.budget)
         report_title = "# Mission Lifetime Report\n\n"

--- a/src/budgie/core/mission_lifetime.py
+++ b/src/budgie/core/mission_lifetime.py
@@ -10,7 +10,7 @@ import numpy as np
 from budgie.version import __version__
 
 NAME = "mission_lifetime.yaml"
-YAML_LOC = f"../data/{NAME}"
+YAML_LOC = f"../budgets/yaml/{NAME}"
 
 class MissionLifetime(Budget):
 
@@ -173,8 +173,9 @@ class MissionLifetime(Budget):
         # Method that is called by a generic script
         # needs to be in every budget class.
         print("Running report method for mission lifetime...")
+        report_name = NAME.replace(".yaml", "md")
+        path = output_dir.joinpath(report_name)
         yaml = pprint.pformat(self.ml.budget)
-        path = output_dir.joinpath("ml-report.md")
         report_title = "# Mission Lifetime Report\n\n"
         end = "\n"
         version = f"**Version:** _{__version__}_\n\n" 

--- a/src/budgie/core/transient_response.py
+++ b/src/budgie/core/transient_response.py
@@ -12,7 +12,7 @@ from budgie.version import __version__
 
 #BUDGET_DATA_DIR = Path(__file__).parents[2].joinpath("data")
 NAME = "transient_response.yaml"
-YAML_LOC = f"../data/{NAME}"
+YAML_LOC = f"../budgets/yaml/{NAME}"
 
 
 class TransientResponse(Budget):
@@ -62,13 +62,14 @@ class TransientResponse(Budget):
         # Method that is called by a generic script
         # needs to be in every budget class.
         print("Running Transient Response Report...")
+        report_name = NAME.replace(".yaml", "md")
+        path = output_dir.joinpath(report_name)
         report_title = "# Transient Response Report\n\n"
         data_header = "## Transient Response Results\n\n"
         version = f"**Version:** _{__version__}_\n\n" 
         total_cbe, total_spec, total_allocation = self.calc_total_time()
         yaml = pprint.pformat(self.tr.budget)
         yaml_data = f"## [Transient Response Yaml]({YAML_LOC})\n\n```yaml\n {yaml} \n```\n"
-        path = output_dir.joinpath("tr-report.md")
         end = "\n"
 
         total_cbe_time = f"- Total CBE Time [min]: {total_cbe/60:0.2f} [min]\n"

--- a/src/budgie/core/transient_response.py
+++ b/src/budgie/core/transient_response.py
@@ -62,7 +62,7 @@ class TransientResponse(Budget):
         # Method that is called by a generic script
         # needs to be in every budget class.
         print("Running Transient Response Report...")
-        report_name = NAME.replace(".yaml", "md")
+        report_name = NAME.replace(".yaml", ".md")
         path = output_dir.joinpath(report_name)
         report_title = "# Transient Response Report\n\n"
         data_header = "## Transient Response Results\n\n"

--- a/src/budgie/core/wavefront_error.py
+++ b/src/budgie/core/wavefront_error.py
@@ -28,7 +28,7 @@ class WaveFrontError(Budget):
         self.wfe.calc_margins()
 
     def calc_total_wfe(self):
-        """Calculates totals ofCBE, allocation, and spec"""
+        """Calculates totals of CBE, allocation, and spec"""
 
         # Use recursion to go infinitely deep and get each curr_cbe, curr_spec, and allocation
 

--- a/src/budgie/core/wavefront_error.py
+++ b/src/budgie/core/wavefront_error.py
@@ -12,20 +12,23 @@ from budgie.core import Budget, find_vals
 from budgie.version import __version__
 
 NAME = "wavefront_error.yaml"
-YAML_LOC = f"../data/{NAME}"
-
+YAML_LOC = f"../budgets/yaml/{NAME}"
 
 class WaveFrontError(Budget):
 
-    def __init__(self):
+    def __init__(self, name):
         print("initialized WaveFrontError class")
         # instantiate the budget class
         super(Budget, self).__init__()
+
+        self.name = name
+        global NAME
+        NAME = self.name
         self.wfe = Budget(NAME)
         self.wfe.calc_margins()
 
     def calc_total_wfe(self):
-        """Calculates totals of CBE, allocation, and spec"""
+        """Calculates totals ofCBE, allocation, and spec"""
 
         # Use recursion to go infinitely deep and get each curr_cbe, curr_spec, and allocation
 
@@ -47,7 +50,8 @@ class WaveFrontError(Budget):
         """
         # Method that is called by a generic script
         # needs to be in every budget class.
-        path = output_dir.joinpath("wfe-report.md")
+        report_name = NAME.replace(".yaml",".md")
+        path = output_dir.joinpath(report_name)
         report_title = "# Wavefront Error Report\n\n"
         yaml = pprint.pformat(self.wfe.budget)
         report_budget = f"## [WFE Yaml Reference]({YAML_LOC})\n\n```yaml\n {yaml} \n```\n"

--- a/src/budgie/core/wavefront_error.py
+++ b/src/budgie/core/wavefront_error.py
@@ -50,6 +50,8 @@ class WaveFrontError(Budget):
         """
         # Method that is called by a generic script
         # needs to be in every budget class.
+        global YAML_LOC
+        YAML_LOC = f"../budgets/yaml/{NAME}"
         report_name = NAME.replace(".yaml",".md")
         path = output_dir.joinpath(report_name)
         report_title = "# Wavefront Error Report\n\n"


### PR DESCRIPTION
Adds feature for allowing multiple wfe files and create a report for each of them using the appropriate name and pathing to the original yaml source file. This is only implemented for the wavefront-error budget class at the moment for this PR. 

Closes #15 